### PR TITLE
refactoring logic for validating params on singleCountry route

### DIFF
--- a/client/src/components/SingleCountry/index.js
+++ b/client/src/components/SingleCountry/index.js
@@ -2,15 +2,8 @@ import CountryCards from "../CountryCards";
 import "./SingleCountry.scss";
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery } from '@apollo/client';
-import { QUERY_COUNTRIES, QUERY_SINGLE_COMPILATION, QUERY_COUNTRY, QUERY_VALID_COUNTRY } from '../../utils/queries';
-import SearchCountry from '../../components/SearchCountry';
+import { QUERY_SINGLE_COMPILATION } from '../../utils/queries';
 import { useSearch } from '../../utils/CountryContext';
-
-// const { countryname: countryParam } = useParams();
-//  const { loading, data } = useQuery(countryParam ? QUERY_SINGLE_COMPILATION : QUERY_COUNTRIES, {
-//   variables: {countryname: countryParam}
-// });
-// const countries = data?.singleCompileCountry || data?.countries || [];
 
 export default function SingleCountry({ countryYearIndex }) {
   const { searches, countryImgs} = useSearch();
@@ -27,26 +20,21 @@ export default function SingleCountry({ countryYearIndex }) {
 
   caseTransformedCountryParam = caseTransformedCountryParam.join(' ')
 
-  const { loading: validCountryLoading, data: validCountryData } = useQuery(QUERY_VALID_COUNTRY, {
-    variables: {country: caseTransformedCountryParam}
-  })
-
-  // tests if the validCountryData is indeed a match to a valid country
-  // via a graphql query
-  if (validCountryData && validCountryData.validCountryName === null) {
-    navigate('/', { replace: true });
-  }
-
   const { loading, data } = useQuery(QUERY_SINGLE_COMPILATION,{
     variables:{countryname : caseTransformedCountryParam}
   });
+  
+  if (data && data?.singleCompileCountry === null) {
+    navigate('/', { replace: true });
+  }
 
-  const singleCountry = data?.singleCompileCountry.year_catalog || [];
+  const singleCountry = data?.singleCompileCountry?.year_catalog || [];
 
   return(
     <div className='containerCenter'>
         <div className='countryCardContainer'>
-        {loading ? (
+        {/* accounts for letting asynchronous conditional check of navigate to homepage to assess before possibly passing year_catalog that is undefined */}
+        {(loading || data.singleCompileCountry === null )? (
             <div>Loading...</div>
           ) : (
             <>

--- a/client/src/utils/queries.js
+++ b/client/src/utils/queries.js
@@ -144,10 +144,3 @@ export const QUERY_SINGLE_COMPILATION = gql`
     }
   }
 `
-export const QUERY_VALID_COUNTRY = gql`
-  query ValidCountry($country: String!) {
-    validCountryName(country: $country) {
-      country
-    }
-  }
-`

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -29,9 +29,6 @@ const resolvers = {
     singleCompileCountry: async (parent, { countryname }) => {
       return CompileCountry.findOne({ countryname }).populate('year_catalog')
     },
-    validCountryName: async (parent, { country }) => {
-      return await Country.findOne({ country })
-    }
   },
 
   Mutation: {

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -70,7 +70,6 @@ const typeDefs = gql`
     countries: [Country]
     countryCompilations: [CountryCompilation]
     singleCompileCountry(countryname: String!): CountryCompilation
-    validCountryName(country: String!): Country
   }
 
   type Mutation {


### PR DESCRIPTION
The previous logic worked via using query_valid_country that had logic that evaluated prior to reaching the return ternary countryCards

However this required making two calls to the database and a hacky solution that relied on asynchronous timing; this new logic only does one database call and still accounts for asynchronous results trying to load data.singleCountryCompilation.year_catalog even when data.singleCountryCompilation returns null