### PR TITLE
Rhong compare country styling and refactoring

### DIFF
--- a/client/src/components/GeoChart/GeoChart.scss
+++ b/client/src/components/GeoChart/GeoChart.scss
@@ -3,8 +3,8 @@
   align-items: center;
 }
 
-.range-modal input[orient=vertical] {
-  transform:rotate(90deg);
+.range-modal input[type='range'] {
+  transform:rotate(270deg);
 }
 
 .chart-title {

--- a/client/src/components/GeoChart/index.js
+++ b/client/src/components/GeoChart/index.js
@@ -53,16 +53,16 @@ const GeoChart =
 
   const savedGeoCountries = geoCitiesInLocalStorage ? JSON.parse(geoCitiesInLocalStorage) : 
   {
-    '2013': [['Country', `SPI Rank (${countryYearIndexToYearMap[countryYearIndex]})`]],
-    '2014': [['Country', `SPI Rank (${countryYearIndexToYearMap[countryYearIndex]})`]],
-    '2015': [['Country', `SPI Rank (${countryYearIndexToYearMap[countryYearIndex]})`]],
-    '2016': [['Country', `SPI Rank (${countryYearIndexToYearMap[countryYearIndex]})`]],
-    '2017': [['Country', `SPI Rank (${countryYearIndexToYearMap[countryYearIndex]})`]],
-    '2018': [['Country', `SPI Rank (${countryYearIndexToYearMap[countryYearIndex]})`]],
-    '2019': [['Country', `SPI Rank (${countryYearIndexToYearMap[countryYearIndex]})`]],
-    '2020': [['Country', `SPI Rank (${countryYearIndexToYearMap[countryYearIndex]})`]],
-    '2021': [['Country', `SPI Rank (${countryYearIndexToYearMap[countryYearIndex]})`]],
-    '2022': [['Country', `SPI Rank (${countryYearIndexToYearMap[countryYearIndex]})`]], 
+    '2013': [['Country', 'SPI Rank (2013)']],
+    '2014': [['Country', 'SPI Rank (2014)']],
+    '2015': [['Country', 'SPI Rank (2015)']],
+    '2016': [['Country', 'SPI Rank (2016)']],
+    '2017': [['Country', 'SPI Rank (2017)']],
+    '2018': [['Country', 'SPI Rank (2018)']],
+    '2019': [['Country', 'SPI Rank (2019)']],
+    '2020': [['Country', 'SPI Rank (2020)']],
+    '2021': [['Country', 'SPI Rank (2021)']],
+    '2022': [['Country', 'SPI Rank (2022)']], 
   };
 
   if (!geoCitiesInLocalStorage) { 

--- a/client/src/components/GeoChart/index.js
+++ b/client/src/components/GeoChart/index.js
@@ -52,25 +52,15 @@ const GeoChart =
   };
 
   const savedGeoCountries = geoCitiesInLocalStorage ? JSON.parse(geoCitiesInLocalStorage) : 
-  {
-    '2013': [['Country', 'SPI Rank (2013)']],
-    '2014': [['Country', 'SPI Rank (2014)']],
-    '2015': [['Country', 'SPI Rank (2015)']],
-    '2016': [['Country', 'SPI Rank (2016)']],
-    '2017': [['Country', 'SPI Rank (2017)']],
-    '2018': [['Country', 'SPI Rank (2018)']],
-    '2019': [['Country', 'SPI Rank (2019)']],
-    '2020': [['Country', 'SPI Rank (2020)']],
-    '2021': [['Country', 'SPI Rank (2021)']],
-    '2022': [['Country', 'SPI Rank (2022)']], 
-  };
+  {};
 
   if (!geoCitiesInLocalStorage) { 
     countries.forEach(country => {
       country.year_catalog.forEach(individualYear => {
         if (individualYear.status === "Ranked") {
           const newGeoData = [country.countryname, individualYear.rank_score_spi]
-          savedGeoCountries[individualYear.spiyear].push(newGeoData);
+          savedGeoCountries[individualYear.spiyear] ? savedGeoCountries[individualYear.spiyear].push(newGeoData) :
+          savedGeoCountries[individualYear.spiyear] = [['Country', `SPI Rank (${individualYear.spiyear})`], newGeoData];
         };
       });
     });


### PR DESCRIPTION
- changing range input within geoChart to be rotated 270 degrees instead of 90 degrees as arrow key up/key down matches now
- refactored parts of savedGeoCountries to be dynamically made within a ternary within localStorage rather than previous hardcode