### PR TITLE
Rhong correcting seed data

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { ApolloClient, InMemoryCache, ApolloProvider, createHttpLink } from '@apollo/client';
 import { setContext } from '@apollo/client/link/context';
-import { BrowserRouter as HashRouter, Routes, Route } from 'react-router-dom';
+import { HashRouter, Routes, Route } from 'react-router-dom';
 import Dashboard from './pages/Dashboard';
 import Login from './pages/Login';
 import Signup from './pages/Signup';

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { ApolloClient, InMemoryCache, ApolloProvider, createHttpLink } from '@apollo/client';
 import { setContext } from '@apollo/client/link/context';
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { BrowserRouter as HashRouter, Routes, Route } from 'react-router-dom';
 import Dashboard from './pages/Dashboard';
 import Login from './pages/Login';
 import Signup from './pages/Signup';
@@ -53,7 +53,7 @@ function App() {
   return (
     <ApolloProvider client={client}>
       <SearchProvider>
-        <Router>
+        <HashRouter>
           <Routes>
             <Route
               path='/AboutUs'
@@ -130,7 +130,7 @@ function App() {
               element={<Splash />}
             />
           </Routes>
-        </Router>
+        </HashRouter>
       </SearchProvider>
 
 

--- a/client/src/components/GeoChart/GeoChart.scss
+++ b/client/src/components/GeoChart/GeoChart.scss
@@ -4,14 +4,14 @@
 }
 
 .range-modal input[type='range'] {
-  transform:rotate(270deg);
+  transform: rotate(270deg);
 }
 
 .chart-title {
   display: flex;
   justify-content: center;
   color: var(--lightBorder);
-  padding-left:133px;
+  padding-left: 133px;
 }
 
 #rangeYearText-modal {

--- a/client/src/components/GeoChart/index.js
+++ b/client/src/components/GeoChart/index.js
@@ -21,7 +21,7 @@ const GeoChart =
   comparedCountryData,
   setComparedCountryData,
 }) => {
-  const geoCitiesInLocalStorage = localStorage.getItem('saved_geo_countries')
+  const geoCitiesInLocalStorage = localStorage.getItem('saved_geo_countries');
   let navigate = useNavigate();
   const { loading, data } = useQuery(QUERY_COMPILATIONS, {
     skip: geoCitiesInLocalStorage
@@ -34,8 +34,8 @@ const GeoChart =
 
   useEffect(() => {
     if (!comparedCountryLoading && newComparedCountryData) {
-      setComparedCountryData(newComparedCountryData?.singleCompileCountry?.year_catalog || [])
-    }
+      setComparedCountryData(newComparedCountryData?.singleCompileCountry?.year_catalog || []);
+    };
   }, [comparedCountryLoading, newComparedCountryData, comparedCountryData, setComparedCountryData]);
 
   const countryYearIndexToYearMap = {
@@ -58,7 +58,7 @@ const GeoChart =
     countries.forEach(country => {
       country.year_catalog.forEach(individualYear => {
         if (individualYear.status === "Ranked") {
-          const newGeoData = [country.countryname, individualYear.rank_score_spi]
+          const newGeoData = [country.countryname, individualYear.rank_score_spi];
           savedGeoCountries[individualYear.spiyear] ? savedGeoCountries[individualYear.spiyear].push(newGeoData) :
           savedGeoCountries[individualYear.spiyear] = [['Country', `SPI Rank (${individualYear.spiyear})`], newGeoData];
         };
@@ -91,17 +91,18 @@ const GeoChart =
   const handleSetCountry = async (region) => {
     if (!loadingC && dataC) {
       await addCountry({ variables: {userId: dataC?.me?._id, searchedCountries: region }});
-    }
+    };
     setCurrentSearchedCountry(region);
     searchCountryImages(region);
     navigate(`/SingleCountry/${region}`);
     onClose();
   }
+
   const handleCompareClick = async (region) => {
     setComparedCountry(region);
     await delayedCompare({ variables: { countryname: region }});
     onClose();
-  }
+  };
 
   return (
     <div className="container">
@@ -155,5 +156,5 @@ const GeoChart =
       </div>
     </div>
   );
-}
+};
 export default GeoChart;

--- a/client/src/components/GeoChart/index.js
+++ b/client/src/components/GeoChart/index.js
@@ -81,12 +81,12 @@ const GeoChart =
     backgroundColor: "#94b0da",
   };
 
-  const filteredCountries = () => {
-   return savedGeoCountries[countryYearIndexToYearMap[countryYearIndex]]?.filter(individualGeoData => {
-      const [name, spi_score] = individualGeoData;
-      return name !== currentSearchedCountry;
-    });
-  };
+  // const filteredCountries = () => {
+  //  return savedGeoCountries[countryYearIndexToYearMap[countryYearIndex]]?.filter(individualGeoData => {
+  //     const [name, spi_score] = individualGeoData;
+  //     return name !== currentSearchedCountry;
+  //   });
+  // };
 
   const handleSetCountry = async (region) => {
     if (!loadingC && dataC) {
@@ -129,7 +129,7 @@ const GeoChart =
           width={'60vw'}
           height={'auto'}
           chartType="GeoChart"
-          data={filteredCountries()}
+          data={savedGeoCountries[countryYearIndexToYearMap[countryYearIndex]]}
           // Note: you will need to get a mapsApiKey for your project.
           // See: https://developers.google.com/chart/interactive/docs/basic_load_libs#load-settings
           mapsApiKey={process.env.REACT_APP_GOOGLE_CHART_API_KEY}
@@ -142,7 +142,7 @@ const GeoChart =
                 const chart = chartWrapper.getChart();
                 const selection = chart.getSelection();
                 if (selection.length === 0) return;
-                const [region, spi_score] = filteredCountries()[selection[0].row + 1]; 
+                const [region, spi_score] = savedGeoCountries[countryYearIndexToYearMap[countryYearIndex]][selection[0].row + 1]; 
 
                 if (!comparisonEnabled) {
                   handleSetCountry(region);

--- a/server/seeders/seed.js
+++ b/server/seeders/seed.js
@@ -34,57 +34,53 @@ db.once('open', async () => {
           },
         }
       );
-    }
-
-  
+    };
   } catch (err) {
     console.error(err);
     process.exit(1);
-  }
+  };
 
   try {
     await Country.deleteMany({});
     await CompileCountry.deleteMany({});
 
     for (let i = 0; i < countrySeed.length; i++) {
-        if (parseInt(countrySeed[i].spiyear) >= 2013 && countrySeed[i].status === "Ranked" ) { // greater than 2013 
-            const newData = await Country.create(
-              {
-                country: formatCountryName(countrySeed[i].country),
-                spiyear: countrySeed[i].spiyear,
-                rank_score_spi: countrySeed[i].rank_score_spi,
-                status: countrySeed[i].status,
-                score_spi: countrySeed[i].score_spi,
-                score_bhn: countrySeed[i].score_bhn,
-                bhn : {
-                     score_nbmc:countrySeed[i].score_nbmc,
-                     score_ws:countrySeed[i].score_ws,
-                     score_sh:countrySeed[i].score_sh,
-                     score_ps:countrySeed[i].score_ps
-                },
-                score_fow: countrySeed[i].score_fow,
-                fow : {
-                    score_abk:countrySeed[i].score_abk,
-                    score_aic:countrySeed[i].score_aic,
-                    score_hw:countrySeed[i].score_hw,
-                    score_eq:countrySeed[i].score_eq
-                },
-                score_opp: countrySeed[i].score_opp,
-                opp : {
-                    score_pr:countrySeed[i].score_pr,
-                    score_pfc:countrySeed[i].score_pfc,
-                    score_incl:countrySeed[i].score_incl,
-                    score_aae:countrySeed[i].score_aae
-                }
-            });
-            await CompileCountry.updateOne({ countryname: formatCountryName(countrySeed[i].country) }, { $push: { year_catalog: newData } }, { upsert : true })
-        }
-
+      if (parseInt(countrySeed[i].spiyear) >= 2013 && countrySeed[i].status === "Ranked") { // greater than 2013 
+        const newData = await Country.create({
+          country: formatCountryName(countrySeed[i].country),
+          spiyear: countrySeed[i].spiyear,
+          rank_score_spi: countrySeed[i].rank_score_spi,
+          status: countrySeed[i].status,
+          score_spi: countrySeed[i].score_spi,
+          score_bhn: countrySeed[i].score_bhn,
+          bhn : {
+                score_nbmc:countrySeed[i].score_nbmc,
+                score_ws:countrySeed[i].score_ws,
+                score_sh:countrySeed[i].score_sh,
+                score_ps:countrySeed[i].score_ps
+          },
+          score_fow: countrySeed[i].score_fow,
+          fow : {
+              score_abk:countrySeed[i].score_abk,
+              score_aic:countrySeed[i].score_aic,
+              score_hw:countrySeed[i].score_hw,
+              score_eq:countrySeed[i].score_eq
+          },
+          score_opp: countrySeed[i].score_opp,
+          opp : {
+              score_pr:countrySeed[i].score_pr,
+              score_pfc:countrySeed[i].score_pfc,
+              score_incl:countrySeed[i].score_incl,
+              score_aae:countrySeed[i].score_aae
+          }
+        });
+        await CompileCountry.updateOne({ countryname: formatCountryName(countrySeed[i].country) }, { $push: { year_catalog: newData } }, { upsert : true });
+      }
     }
   } catch (err) {
       console.error(err);
       process.exit(1);
-  }
+  };
 
   console.log('all done!');
   process.exit(0);

--- a/server/seeders/seed.js
+++ b/server/seeders/seed.js
@@ -8,7 +8,7 @@ const countrySeed = require('./2011-2022 SPI data-Table 1.json');
 const formatCountryName = (countryName) => {
   if (!countryName.includes(',')) {
     return countryName;
-  }
+  };
 
   const [beforeComma, afterComma] = countryName.split(',');
   return afterComma.trimStart().concat(' ').concat(beforeComma);

--- a/server/seeders/seed.js
+++ b/server/seeders/seed.js
@@ -40,10 +40,19 @@ db.once('open', async () => {
     await CompileCountry.deleteMany({});
 
     for (let i = 0; i < countrySeed.length; i++) {
-        if (parseInt(countrySeed[i].spiyear) >= 2013 && countrySeed[i].country !== "World") { // greater than 2013 
+        if (parseInt(countrySeed[i].spiyear) >= 2013 && countrySeed[i].status === "Ranked" ) { // greater than 2013 
+
+            let revisedCountryName = ''
+            if (!countrySeed[i].country.includes(',')) {
+              revisedCountryName = countrySeed[i].country;
+            } else {
+              const [beforeComma, afterComma] = countrySeed[i].country.split(',');
+              revisedCountryName = afterComma.trimStart().concat(' ').concat(beforeComma);
+            };
+
             const newData = await Country.create(
               {
-                country: countrySeed[i].country,
+                country: revisedCountryName,
                 spiyear: countrySeed[i].spiyear,
                 rank_score_spi: countrySeed[i].rank_score_spi,
                 status: countrySeed[i].status,
@@ -70,7 +79,7 @@ db.once('open', async () => {
                     score_aae:countrySeed[i].score_aae
                 }
             });
-            await CompileCountry.updateOne({ countryname: countrySeed[i].country }, { $push: { year_catalog: newData } }, { upsert : true })
+            await CompileCountry.updateOne({ countryname: revisedCountryName }, { $push: { year_catalog: newData } }, { upsert : true })
         }
 
     }

--- a/server/seeders/seed.js
+++ b/server/seeders/seed.js
@@ -5,6 +5,14 @@ const userSeeds = require('./userSeeds.json');
 const commentSeeds = require('./commentSeeds.json');
 const countrySeed = require('./2011-2022 SPI data-Table 1.json');
 
+const formatCountryName = (countryName) => {
+  if (!countryName.includes(',')) {
+    return countryName;
+  }
+
+  const [beforeComma, afterComma] = countryName.split(',');
+  return afterComma.trimStart().concat(' ').concat(beforeComma);
+};
 
 db.once('open', async () => {
   try {
@@ -34,25 +42,15 @@ db.once('open', async () => {
     process.exit(1);
   }
 
-
   try {
     await Country.deleteMany({});
     await CompileCountry.deleteMany({});
 
     for (let i = 0; i < countrySeed.length; i++) {
         if (parseInt(countrySeed[i].spiyear) >= 2013 && countrySeed[i].status === "Ranked" ) { // greater than 2013 
-
-            let revisedCountryName = ''
-            if (!countrySeed[i].country.includes(',')) {
-              revisedCountryName = countrySeed[i].country;
-            } else {
-              const [beforeComma, afterComma] = countrySeed[i].country.split(',');
-              revisedCountryName = afterComma.trimStart().concat(' ').concat(beforeComma);
-            };
-
             const newData = await Country.create(
               {
-                country: revisedCountryName,
+                country: formatCountryName(countrySeed[i].country),
                 spiyear: countrySeed[i].spiyear,
                 rank_score_spi: countrySeed[i].rank_score_spi,
                 status: countrySeed[i].status,
@@ -79,7 +77,7 @@ db.once('open', async () => {
                     score_aae:countrySeed[i].score_aae
                 }
             });
-            await CompileCountry.updateOne({ countryname: revisedCountryName }, { $push: { year_catalog: newData } }, { upsert : true })
+            await CompileCountry.updateOne({ countryname: formatCountryName(countrySeed[i].country) }, { $push: { year_catalog: newData } }, { upsert : true })
         }
 
     }


### PR DESCRIPTION
- changing BrowserRouter to HashRouter within App.js to fix refresh crashing on Heroku site
- commenting out filteredCountries in geoCharts (which made interactive map effectively make regions that were just searched unclickable/appear as a region that isn't mapped e.g. United States previously searched and then trying to click United States again in the world map), needs more work or possible discussion to scrap idea altogether
- found that the json in which seeds are made from were somehow incorrect on some ranked countries where their country values were shifted incorrectly one away from expected. This caused country.spiyear to show as a string rather than a number which made the conditional statement of spiyear needing to be >= 2013 skip those countries. This is now fixed with corrected json data and logic is used to format country names that were wayward e.g. "Korea, Republic of" is formatted to "Republic of Korea"
- various addition of semicolons sprinkled in code