### PR TITLE
Refactoring state prop drilling with React context

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { ApolloClient, InMemoryCache, ApolloProvider, createHttpLink } from '@apollo/client';
 import { setContext } from '@apollo/client/link/context';
 import { HashRouter, Routes, Route } from 'react-router-dom';
@@ -19,7 +19,6 @@ import Visa from './pages/Visa';
 import './App.scss';
 
 import { SearchProvider } from './utils/CountryContext';
-
 
 // Construct our main GraphQL API endpoint
 const httpLink = createHttpLink({
@@ -46,10 +45,8 @@ export const client = new ApolloClient({
   cache: new InMemoryCache(),
 });
 
-function App() {
-  const [countryYearIndex, setCountryYearIndex] = useState(9);
-  const [currentSearchedCountry, setCurrentSearchedCountry] = useState("");
 
+function App() {
   return (
     <ApolloProvider client={client}>
       <SearchProvider>
@@ -66,12 +63,7 @@ function App() {
             <Route
               index
               element={
-                <Splash 
-                  countryYearIndex={countryYearIndex} 
-                  setCountryYearIndex={setCountryYearIndex} 
-                  currentSearchedCountry={currentSearchedCountry} 
-                  setCurrentSearchedCountry={setCurrentSearchedCountry}
-                />
+                <Splash />
               }
             />
             <Route
@@ -89,12 +81,7 @@ function App() {
             /> */}
             <Route
               path="/SingleCountry/:countryname"
-              element={<SingleCountryCont 
-                          countryYearIndex={countryYearIndex} 
-                          setCountryYearIndex={setCountryYearIndex} 
-                          currentSearchedCountry={currentSearchedCountry} 
-                          setCurrentSearchedCountry={setCurrentSearchedCountry}
-                        />}
+              element={<SingleCountryCont />}
             />
             {/* <Route
               path="/listings"
@@ -114,16 +101,10 @@ function App() {
             />
             <Route
               path="/dashboard"
-              element={<Dashboard countryYearIndex={countryYearIndex} 
-              setCountryYearIndex={setCountryYearIndex}
-              currentSearchedCountry={currentSearchedCountry}
-              setCurrentSearchedCountry={setCurrentSearchedCountry}/>} />
+              element={<Dashboard />} />
             <Route 
               path="/dashboard/:username" 
-              element={<Dashboard countryYearIndex={countryYearIndex} 
-              setCountryYearIndex={setCountryYearIndex}
-              currentSearchedCountry={currentSearchedCountry}
-              setCurrentSearchedCountry={setCurrentSearchedCountry}/>}
+              element={<Dashboard />}
             />
             <Route
               path="/*"
@@ -132,10 +113,8 @@ function App() {
           </Routes>
         </HashRouter>
       </SearchProvider>
-
-
     </ApolloProvider>
   );
-}
+};
 
 export default App;

--- a/client/src/components/CompareCountry/index.js
+++ b/client/src/components/CompareCountry/index.js
@@ -3,23 +3,23 @@ import SwitchToggle from '../SwitchToggle';
 import { useQuery, useLazyQuery } from '@apollo/client';
 import { QUERY_COMPILATIONS, QUERY_SINGLE_COMPILATION } from '../../utils/queries';
 import { capitalizeFirstLetter } from '../../utils/helper';
+import { useSearch } from '../../utils/CountryContext';
+import { useDrawer } from '../../utils/DrawerContext';
 import Modal from '../Modal';
 import ReactTooltip from 'react-tooltip';
 import './CompareCountry.scss';
 
-const CompareCountry = ({
-  comparisonEnabled,
-  setComparisonEnabled,
-  baseCountry,
-  comparedCountry,
-  setComparedCountry,
-  comparedCountryData,
-  setComparedCountryData,
-  countryYearIndex,
-  setCountryYearIndex,
-  currentSearchedCountry,
-  setCurrentSearchedCountry
-}) => {
+const CompareCountry = () => {
+  const {
+    currentSearchedCountry
+  } = useSearch();
+  const {
+    comparisonEnabled,
+    setComparisonEnabled,
+    comparedCountry,
+    setComparedCountry,
+    setComparedCountryData
+  } = useDrawer();
   const [suggestions, setSuggestions] = useState([]);
   const [modalOpen, setModalOpen] = useState(false);
   const { loading, data } = useQuery(QUERY_COMPILATIONS);
@@ -49,7 +49,7 @@ const CompareCountry = ({
 
       matches = countries.filter(country => {
         const regex = new RegExp(`${text}`, "gi");
-        return country.countryname !== baseCountry && country.countryname.match(regex)
+        return country.countryname !== currentSearchedCountry && country.countryname.match(regex)
       })
     }
     setSuggestions(matches);
@@ -108,26 +108,15 @@ const CompareCountry = ({
               <div className='suggestion'
                 key={i}
                 onClick={() => onSuggestHandler(suggestions.countryname)}
-
               >{suggestions.countryname}</div>
             )}
           </div>
           <Modal
             isOpen={modalOpen}
             onClose={() => setModalOpen(false)}
-            countryYearIndex={countryYearIndex}
-            setCountryYearIndex={setCountryYearIndex}
-            currentSearchedCountry={currentSearchedCountry}
-            setCurrentSearchedCountry={setCurrentSearchedCountry}
-            comparisonEnabled={true}
-            comparedCountry={comparedCountry}
-            setComparedCountry={setComparedCountry}
-            comparedCountryData={comparedCountryData}
-            setComparedCountryData={setComparedCountryData}
           />
         </>
-      }
-      
+      } 
       </>
   )
 }

--- a/client/src/components/CountryCards/index.js
+++ b/client/src/components/CountryCards/index.js
@@ -1,4 +1,6 @@
 import React, { useState, useRef } from "react";
+import { useSearch } from '../../utils/CountryContext';
+import { useDrawer } from '../../utils/DrawerContext';
 import './CountryCards.scss';
 import { gsap } from 'gsap'
 import { Flip } from "gsap/Flip";
@@ -36,7 +38,6 @@ const expand = (event) => {
     let jumpY = box.getBoundingClientRect();
     window.scroll({ top: jumpY.y, left: 0, behavior: 'smooth' });
 
-
     // Animate from the initial state to the end state!
 
     Flip.from(state, {
@@ -44,20 +45,10 @@ const expand = (event) => {
         nested: true,
         scale: true,
     });
-
-
 }
 
 
-export default function CountryCards({ 
-        countryProperties, 
-        countryYearIndex, 
-        chartTypeIndex, 
-        comparedCountryProperties,
-        comparisonEnabled,
-        comparedCountry,
-        currentSearchedCountry
-    }) {
+export default function CountryCards({ countryProperties }) {
     let ref1 = useRef(null);
     let ref2 = useRef(null);
     let ref3 = useRef(null);
@@ -71,136 +62,140 @@ export default function CountryCards({
     let ref11 = useRef(null);
     let ref12 = useRef(null);
     const [toggle, setToggle] = useState(false);
+    const { countryYearIndex, currentSearchedCountry } = useSearch();
+    const {
+        chartTypeIndex,
+        comparisonEnabled,
+        comparedCountry,
+        comparedCountryData
+    } = useDrawer();
 
     return (
-        <>
-            
-                {
-                    [ref1, ref2, ref3, ref4, ref5, ref6, ref7, ref8, ref9, ref10, ref11, ref12].map((d, i) => {
-                        return (
-                            <div key={i}
-                                className="countryCard"
-                                ref={d}
-                                id={`col${i%3 + 1}row${Math.floor(i/3) + 1}`}
-                                data-name={`col${i%3 + 1}row${Math.floor(i/3) + 1}`}
-                                onClick={(event) => {
-                                    expand(event)
-                                    setToggle(!toggle)
-                                }}
-                                data-column={`${i+1}`}
-                            >
-                                { d?.current?.classList?.contains('wide') ?
-                               
-                                    (<>
-                                        <section className='expandedCardInfo'>
-                                            <div className='cardIcon'>
-                                                <img src={columnData[i].ImgSrc} alt={columnData[i].ImgAlt} />
-                                            </div>
-                                            <div className='cardTitle'>
-                                                <h3>{columnData[i].src.h3}</h3>
-                                                <p className='cardValue'>{(countryProperties[countryYearIndex][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`]).toString()}</p>
-                                            </div>
-                                            <h4 className="expandedDivider">Scores based on...</h4>
-                                            <ul>
-                                                {
-                                                    columnData[i].description.map((val,i) =>{
-                                                        return(
-                                                            <li key={i}>{val}</li>
-                                                        )
-                                                    })
-                                                }
-                                               
-                                            </ul>
-
-                                            <p className='clickHere'>Click to close...</p>
-
-                                        </section>
-
-                                        <div className='expandedChartArea'>     
-                                            {(() => {
-                                                const fields = {
-                                                    "2013": countryProperties[0][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
-                                                    "2014": countryProperties[1][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
-                                                    "2015": countryProperties[2][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
-                                                    "2016": countryProperties[3][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
-                                                    "2017": countryProperties[4][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
-                                                    "2018": countryProperties[5][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
-                                                    "2019": countryProperties[6][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
-                                                    "2020": countryProperties[7][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
-                                                    "2021": countryProperties[8][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
-                                                    "2022": countryProperties[9][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
-                                                }
-
-                                                const comparedFields = comparedCountryProperties.length > 0 ? 
-                                                    {
-                                                        "2013": comparedCountryProperties[0][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
-                                                        "2014": comparedCountryProperties[1][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
-                                                        "2015": comparedCountryProperties[2][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
-                                                        "2016": comparedCountryProperties[3][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
-                                                        "2017": comparedCountryProperties[4][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
-                                                        "2018": comparedCountryProperties[5][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
-                                                        "2019": comparedCountryProperties[6][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
-                                                        "2020": comparedCountryProperties[7][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
-                                                        "2021": comparedCountryProperties[8][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
-                                                        "2022": comparedCountryProperties[9][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
-                                                    } :
-                                                    null
-                                                
-                                                
-                                                switch(chartTypeIndex) {
-                                                    case('Bar'):
-                                                        return (
-                                                            <BarChart 
-                                                            fields={fields} countryYearIndex={countryYearIndex}
-                                                            />
-                                                        )
-                                                    case('Line'):
-                                                        return (
-                                                            <LineChart 
-                                                                fields={fields} 
-                                                                countryYearIndex={countryYearIndex}
-                                                                comparedCountryFields={comparedFields}
-                                                                comparisonEnabled={comparisonEnabled}
-                                                                comparedCountry={comparedCountry}
-                                                                currentSearchedCountry={currentSearchedCountry}
-                                                            />
-                                                        )
-                                                    case('Area'):
-                                                        return (
-                                                            <AreaChart 
-                                                            fields={fields} countryYearIndex={countryYearIndex}
-                                                            />
-                                                        )
-                                                    default: 
-                                                        return;
-                                                }
-                                            })()}
-                                        </div>
-                                    </>)
-                                    :
-                                    (<>
-
+        <>   
+            {
+                [ref1, ref2, ref3, ref4, ref5, ref6, ref7, ref8, ref9, ref10, ref11, ref12].map((d, i) => {
+                    return (
+                        <div key={i}
+                            className="countryCard"
+                            ref={d}
+                            id={`col${i%3 + 1}row${Math.floor(i/3) + 1}`}
+                            data-name={`col${i%3 + 1}row${Math.floor(i/3) + 1}`}
+                            onClick={(event) => {
+                                expand(event)
+                                setToggle(!toggle)
+                            }}
+                            data-column={`${i+1}`}
+                        >
+                            { d?.current?.classList?.contains('wide') ?
+                            
+                                (<>
+                                    <section className='expandedCardInfo'>
                                         <div className='cardIcon'>
                                             <img src={columnData[i].ImgSrc} alt={columnData[i].ImgAlt} />
                                         </div>
                                         <div className='cardTitle'>
                                             <h3>{columnData[i].src.h3}</h3>
                                             <p className='cardValue'>{(countryProperties[countryYearIndex][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`]).toString()}</p>
-                                            <p className='clickHere'>Click to see more...</p>
                                         </div>
+                                        <h4 className="expandedDivider">Scores based on...</h4>
+                                        <ul>
+                                            {
+                                                columnData[i].description.map((val,i) =>{
+                                                    return(
+                                                        <li key={i}>{val}</li>
+                                                    )
+                                                })
+                                            }
+                                            
+                                        </ul>
 
-                                    </>)
+                                        <p className='clickHere'>Click to close...</p>
 
-                                }
-                            </div>
+                                    </section>
 
-                        )
-                    })
-                }
-            
-            
+                                    <div className='expandedChartArea'>     
+                                        {(() => {
+                                            const fields = {
+                                                "2013": countryProperties[0][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
+                                                "2014": countryProperties[1][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
+                                                "2015": countryProperties[2][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
+                                                "2016": countryProperties[3][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
+                                                "2017": countryProperties[4][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
+                                                "2018": countryProperties[5][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
+                                                "2019": countryProperties[6][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
+                                                "2020": countryProperties[7][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
+                                                "2021": countryProperties[8][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
+                                                "2022": countryProperties[9][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
+                                            }
+
+                                            const comparedFields = comparedCountryData.length > 0 ? 
+                                                {
+                                                    "2013": comparedCountryData[0][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
+                                                    "2014": comparedCountryData[1][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
+                                                    "2015": comparedCountryData[2][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
+                                                    "2016": comparedCountryData[3][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
+                                                    "2017": comparedCountryData[4][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
+                                                    "2018": comparedCountryData[5][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
+                                                    "2019": comparedCountryData[6][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
+                                                    "2020": comparedCountryData[7][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
+                                                    "2021": comparedCountryData[8][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
+                                                    "2022": comparedCountryData[9][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`],
+                                                } :
+                                                null
+                                            
+                                            
+                                            switch(chartTypeIndex) {
+                                                case('Bar'):
+                                                    return (
+                                                        <BarChart 
+                                                        fields={fields} countryYearIndex={countryYearIndex}
+                                                        />
+                                                    )
+                                                case('Line'):
+                                                    return (
+                                                        <LineChart 
+                                                            fields={fields} 
+                                                            countryYearIndex={countryYearIndex}
+                                                            comparedCountryFields={comparedFields}
+                                                            comparisonEnabled={comparisonEnabled}
+                                                            comparedCountry={comparedCountry}
+                                                            currentSearchedCountry={currentSearchedCountry}
+                                                        />
+                                                    )
+                                                case('Area'):
+                                                    return (
+                                                        <AreaChart 
+                                                        fields={fields} countryYearIndex={countryYearIndex}
+                                                        />
+                                                    )
+                                                default: 
+                                                    return;
+                                            }
+                                        })()}
+                                    </div>
+                                </>)
+                                :
+                                (<>
+
+                                    <div className='cardIcon'>
+                                        <img src={columnData[i].ImgSrc} alt={columnData[i].ImgAlt} />
+                                    </div>
+                                    <div className='cardTitle'>
+                                        <h3>{columnData[i].src.h3}</h3>
+                                        <p className='cardValue'>{(countryProperties[countryYearIndex][`${columnData[i].src.category}`][`${columnData[i].src.fieldName}`]).toString()}</p>
+                                        <p className='clickHere'>Click to see more...</p>
+                                    </div>
+
+                                </>)
+
+                            }
+                        </div>
+
+                    )
+                })
+            }
+ 
         </>
-
     );
 }
 

--- a/client/src/components/Drawer/index.js
+++ b/client/src/components/Drawer/index.js
@@ -1,6 +1,8 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useQuery } from '@apollo/client';
 import { QUERY_COMPILATIONS } from '../../utils/queries';
+import { useSearch } from '../../utils/CountryContext';
+import { useDrawer } from '../../utils/DrawerContext';
 import "./Drawer.scss"
 import CompareCountry from '../CompareCountry';
 import SearchCountry from '../SearchCountry';
@@ -10,20 +12,16 @@ import expandArrow from "../../images/expandArrow.svg"
 
 
 
-export default function Drawer({
-    comparisonEnabled,
-    setComparisonEnabled,
-    baseCountry,
-    comparedCountry,
-    setComparedCountry,
-    comparedCountryData,
-    setComparedCountryData,
-    countryYearIndex,
-    setCountryYearIndex,
-    currentSearchedCountry,
-    setCurrentSearchedCountry,
-    chartTypeIndex,
-    setChartTypeIndex}) {
+export default function Drawer() {
+    const { 
+        countryYearIndex, 
+        setCountryYearIndex, 
+    } = useSearch();
+    const {
+        chartTypeIndex,
+        setChartTypeIndex,
+        comparisonEnabled,
+    } = useDrawer();
     const [drawerOpen, setDrawerOpen] = useState(false);
     const { loading, data } = useQuery(QUERY_COMPILATIONS);
     const [width, setWidth] = useState(window.innerWidth);
@@ -69,25 +67,8 @@ export default function Drawer({
                         </>
                     }
                 </div>
-                <SearchCountry
-                    countryYearIndex={countryYearIndex}
-                    setCountryYearIndex={setCountryYearIndex}
-                    currentSearchedCountry={currentSearchedCountry}
-                    setCurrentSearchedCountry={setCurrentSearchedCountry}
-                />
-                <CompareCountry
-                    comparisonEnabled={comparisonEnabled}
-                    setComparisonEnabled={setComparisonEnabled}
-                    baseCountry={currentSearchedCountry}
-                    comparedCountry={comparedCountry}
-                    setComparedCountry={setComparedCountry}
-                    comparedCountryData={comparedCountryData}
-                    setComparedCountryData={setComparedCountryData}
-                    countryYearIndex={countryYearIndex}
-                    setCountryYearIndex={setCountryYearIndex}
-                    currentSearchedCountry={currentSearchedCountry}
-                    setCurrentSearchedCountry={setCurrentSearchedCountry}
-                />
+                <SearchCountry />
+                <CompareCountry />
                 <hr />
                 <div className='mapDataContain'>
                     <div className="dropdownContainer">

--- a/client/src/components/GeoChart/index.js
+++ b/client/src/components/GeoChart/index.js
@@ -6,21 +6,17 @@ import { useQuery, useLazyQuery, useMutation } from '@apollo/client';
 import { QUERY_COMPILATIONS, QUERY_SINGLE_COMPILATION, QUERY_ME } from '../../utils/queries';
 import { ADD_SEARCH_HISTORY } from '../../utils/mutations';
 import { useSearch } from '../../utils/CountryContext';
+import { useDrawer } from '../../utils/DrawerContext';
 import { searchImage } from '../../utils/API';
 
-const GeoChart = 
-({ 
-  onClose, 
-  comparisonEnabled,
-  countryYearIndex, 
-  setCountryYearIndex, 
-  currentSearchedCountry, 
-  setCurrentSearchedCountry,
-  comparedCountry,
-  setComparedCountry,
-  comparedCountryData,
-  setComparedCountryData,
-}) => {
+const GeoChart = ({ onClose }) => {
+  const { countryYearIndex, setCountryYearIndex, currentSearchedCountry, setCurrentSearchedCountry } = useSearch();
+  const {
+      comparisonEnabled,
+      setComparedCountry,
+      comparedCountryData,
+      setComparedCountryData
+  } = useDrawer();
   const geoCitiesInLocalStorage = localStorage.getItem('saved_geo_countries');
   let navigate = useNavigate();
   const { loading, data } = useQuery(QUERY_COMPILATIONS, {

--- a/client/src/components/Modal/index.js
+++ b/client/src/components/Modal/index.js
@@ -7,15 +7,6 @@ const Modal =
 ({ 
   isOpen, 
   onClose, 
-  countryYearIndex, 
-  setCountryYearIndex, 
-  currentSearchedCountry, 
-  setCurrentSearchedCountry, 
-  comparedCountry,
-  setComparedCountry, 
-  comparedCountryData,
-  setComparedCountryData,
-  comparisonEnabled,
   children 
 }) => {
   const modalRef = useRef();
@@ -48,15 +39,6 @@ const Modal =
       <div className="modalElementsContainer" ref={modalRef}>
         <GeoChart 
           onClose={onClose} 
-          comparisonEnabled={comparisonEnabled}
-          countryYearIndex={countryYearIndex} 
-          setCountryYearIndex={setCountryYearIndex} 
-          currentSearchedCountry={currentSearchedCountry} 
-          setCurrentSearchedCountry={setCurrentSearchedCountry}
-          comparedCountry={comparedCountry}
-          setComparedCountry={setComparedCountry} 
-          comparedCountryData={comparedCountryData}
-          setComparedCountryData={setComparedCountryData}
         />
         <button onClick={onClose}>Close</button>
       </div>

--- a/client/src/components/SearchCountry/index.js
+++ b/client/src/components/SearchCountry/index.js
@@ -3,14 +3,19 @@ import { searchImage } from '../../utils/API';
 import { useQuery, useMutation } from '@apollo/client';
 import { QUERY_COMPILATIONS } from '../../utils/queries';
 import { useSearch } from '../../utils/CountryContext';
+import { DrawerProvider } from '../../utils/DrawerContext';
 import "./SearchCountry.scss";
 import { useNavigate } from 'react-router-dom';
 import Modal from '../Modal';
 import { ADD_SEARCH_HISTORY } from '../../utils/mutations';
 import { QUERY_ME } from '../../utils/queries';
 
-const SearchCountry = ({ countryYearIndex, setCountryYearIndex, currentSearchedCountry, setCurrentSearchedCountry }) => {
-  const { searches, addSearch } = useSearch();
+const SearchCountry = () => {
+  const { 
+    searches, 
+    addSearch, 
+    setCurrentSearchedCountry  
+ } = useSearch();
   //For Search country
   const [searchImgInput, setSearchImgInput] = useState("");
   const [suggestions, setSuggestions] = useState([]);
@@ -74,13 +79,11 @@ const SearchCountry = ({ countryYearIndex, setCountryYearIndex, currentSearchedC
   }
 
   return (
-
     <>
- 
+      <DrawerProvider>
         <div className="singleCountryInput">
           <div className='splashOpenMap'>
           {width > breakPoint && <button onClick={() => setModalOpen(true)}>Open Interactive Map</button>}
-            {/* <OpenModal /> */}
           </div>
           <input
             type="text"
@@ -88,33 +91,24 @@ const SearchCountry = ({ countryYearIndex, setCountryYearIndex, currentSearchedC
             value={searchImgInput}
             onChange={(e) => onChangeHandler(e.target.value)}
           />
-          <button
-            type="submit"
-            onClick={handleFormSubmit}
-          >
+          <button type="submit" onClick={handleFormSubmit}>
             Search
           </button>
         </div>
         <div className='suggestionCont'>   
-        {suggestions && suggestions.map((suggestions, i) =>
-            <div className='suggestion'
-              key={i}
-              onClick={() => onSuggestHandler(suggestions.countryname)}
-            >{suggestions.countryname}</div>
+          {suggestions && suggestions.map((suggestions, i) =>
+              <div className='suggestion'
+                key={i}
+                onClick={() => onSuggestHandler(suggestions.countryname)}
+              >{suggestions.countryname}</div>
           )}
         </div>
-
-      <Modal 
-          isOpen={modalOpen} 
-          onClose={() => setModalOpen(false)}
-          countryYearIndex={countryYearIndex} 
-          setCountryYearIndex={setCountryYearIndex} 
-          currentSearchedCountry={currentSearchedCountry}
-          setCurrentSearchedCountry={setCurrentSearchedCountry}
-          comparisonEnabled={false}
-      />
-      </>
-
+        <Modal 
+            isOpen={modalOpen} 
+            onClose={() => setModalOpen(false)}
+        />
+      </DrawerProvider>
+    </>
   );
 };
 

--- a/client/src/components/SingleCountry/index.js
+++ b/client/src/components/SingleCountry/index.js
@@ -1,63 +1,48 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import CountryCards from "../CountryCards";
 import "./SingleCountry.scss";
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery } from '@apollo/client';
 import { QUERY_SINGLE_COMPILATION } from '../../utils/queries';
 import { useSearch } from '../../utils/CountryContext';
+import { DrawerProvider } from '../../utils/DrawerContext';
 import { capitalizeFirstLetter } from '../../utils/helper'
 import Drawer from '../../components/Drawer';
-import { useRef, useEffect, useState } from 'react';
 
-const SingleCountry =
-  ({
-    countryYearIndex,
-    chartTypeIndex,
-    currentSearchedCountry,
-    comparedCountry,
-    comparedCountryData,
-    comparisonEnabled,
-    setComparisonEnabled,
-    setComparedCountry,
-    setComparedCountryData,
-    setCountryYearIndex,
-    setCurrentSearchedCountry
-  }) => {
-    const { searches, updateSearch } = useSearch();
-    const { countryname: countryParam } = useParams();
-    const navigate = useNavigate();
-    // define height of tab to offset top of container
-    const tabHeight = '130';
-    const cardContainer = useRef();
+const SingleCountry = () => {
+  const { searches, updateSearch } = useSearch();
+  const { countryname: countryParam } = useParams();
+  const navigate = useNavigate();
+  // define height of tab to offset top of container
+  const tabHeight = '130';
+  const cardContainer = useRef();
 
-    // account for transforming manual entries that do not have a capital letter
-    const caseTransformedCountryParam = capitalizeFirstLetter(countryParam);
+  // account for transforming manual entries that do not have a capital letter
+  const caseTransformedCountryParam = capitalizeFirstLetter(countryParam);
 
-    const { loading, data } = useQuery(QUERY_SINGLE_COMPILATION, {
-      variables: { countryname: caseTransformedCountryParam }
-    });
+  const { loading, data } = useQuery(QUERY_SINGLE_COMPILATION, {
+    variables: { countryname: caseTransformedCountryParam }
+  });
 
-    if (data && data?.singleCompileCountry === null) {
-      navigate('/', { replace: true });
+  if (data && data?.singleCompileCountry === null) {
+    navigate('/', { replace: true });
+  }
+
+  const singleCountry = data?.singleCompileCountry?.year_catalog || [];
+
+  //Save more data from country to LocalStorage
+  if (data) {
+    const countryIndex = searches.findIndex(country => country.name === caseTransformedCountryParam)
+    const newData = {
+      ...searches[countryIndex],
+      score_bhn: data.singleCompileCountry.year_catalog[9].score_bhn,
+      score_fow: data.singleCompileCountry.year_catalog[9].score_fow,
+      score_opp: data.singleCompileCountry.year_catalog[9].score_opp,
+      rank_score_spi: data.singleCompileCountry.year_catalog[9].rank_score_spi,
+      score_spi: data.singleCompileCountry.year_catalog[9].score_spi,
     }
-
-    const singleCountry = data?.singleCompileCountry?.year_catalog || [];
-
-    //Save more data from country to LocalStorage
-    if (data) {
-      const countryIndex = searches.findIndex(country => country.name === caseTransformedCountryParam)
-      const newData = {
-        ...searches[countryIndex],
-        score_bhn: data.singleCompileCountry.year_catalog[9].score_bhn,
-        score_fow: data.singleCompileCountry.year_catalog[9].score_fow,
-        score_opp: data.singleCompileCountry.year_catalog[9].score_opp,
-        rank_score_spi: data.singleCompileCountry.year_catalog[9].rank_score_spi,
-        score_spi: data.singleCompileCountry.year_catalog[9].score_spi,
-      }
-      updateSearch(newData);
-    }
-
-    const [targetPosition, setTargetPosition] = useState({ top: 0, left: 0 });
+    updateSearch(newData);
+  }
 
     // useEffect(() => {
     //   if (drawerContainer.current && cardContainer.current) {
@@ -71,21 +56,12 @@ const SingleCountry =
     //   }
     // }, [drawerContainer.current, cardContainer.current]);
 
-    return (
-      <>
-        <div className='containerCenter'>
-          <Drawer  comparisonEnabled={comparisonEnabled}
-            setComparisonEnabled={setComparisonEnabled}
-            baseCountry={currentSearchedCountry}
-            comparedCountry={comparedCountry}
-            setComparedCountry={setComparedCountry}
-            comparedCountryData={comparedCountryData}
-            setComparedCountryData={setComparedCountryData}
-            countryYearIndex={countryYearIndex}
-            setCountryYearIndex={setCountryYearIndex}
-            currentSearchedCountry={currentSearchedCountry}
-            setCurrentSearchedCountry={setCurrentSearchedCountry} />
-          <div className='countryCardContainer' ref={cardContainer} >
+  return (
+    <>
+      <div className='containerCenter'>
+        <DrawerProvider>
+          <Drawer />
+            <div className='countryCardContainer' ref={cardContainer} >
             {/* accounts for letting asynchronous conditional check of navigate to homepage to assess before possibly passing year_catalog that is undefined */}
             {(loading || data.singleCompileCountry === null) ? (
               <div>Loading...</div>
@@ -93,19 +69,14 @@ const SingleCountry =
               <>
                 <CountryCards
                   countryProperties={singleCountry}
-                  countryYearIndex={countryYearIndex}
-                  chartTypeIndex={chartTypeIndex}
-                  comparedCountryProperties={comparedCountryData}
-                  comparisonEnabled={comparisonEnabled}
-                  comparedCountry={comparedCountry}
-                  currentSearchedCountry={currentSearchedCountry}
                 />
               </>
             )}
           </div>
-        </div>
-      </>
-    )
-  }
+        </DrawerProvider>
+      </div>
+    </>
+  );
+};
 
 export default SingleCountry;

--- a/client/src/pages/Dashboard/index.js
+++ b/client/src/pages/Dashboard/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { useQuery } from '@apollo/client';
 import { QUERY_USER, QUERY_ME } from '../../utils/queries';
 import SearchCountry from '../../components/SearchCountry';
@@ -7,22 +7,16 @@ import { useSearch } from '../../utils/CountryContext';
 import "./dashboard.scss";
 import Header from '../../components/Header';
 import Footer from '../../components/Footer';
-import PolarChart from '../../components/CountryPolarChart'
 import FiveSavedSearches from '../../components/FiveSavedSearches';
 
-const Dashboard = ({ countryYearIndex, setCountryYearIndex, currentSearchedCountry, setCurrentSearchedCountry }) => {
-let navigate = useNavigate();
+const Dashboard = () => {
   const { username: userParam } = useParams();
   const { loading: loadingC, data: dataC } = useQuery(userParam ? QUERY_USER : QUERY_ME, {
     variables: { username: userParam }
   });
   
-
   const user = dataC?.me || dataC?.user || {};
   let lastFiveSearches=(dataC?.me?.searchHistory)
-  
-  const { searches } = useSearch();
-
   
   if (loadingC) {
     return <div>Loading...</div>;
@@ -46,7 +40,6 @@ let navigate = useNavigate();
   }
   return (
     <>
-
       <Header />
       <main className='dashMain'>
         <div className="">
@@ -96,10 +89,7 @@ let navigate = useNavigate();
                   }
               {/* </div> */}
               <div className='dashSearch'>
-                <SearchCountry countryYearIndex={countryYearIndex} 
-                            setCountryYearIndex={setCountryYearIndex}
-                            currentSearchedCountry={currentSearchedCountry}
-                            setCurrentSearchedCountry={setCurrentSearchedCountry} />
+                <SearchCountry />
               </div>
             </div>
             {/* <button type="submit" onClick={handleLogout}>Log Out</button> */}

--- a/client/src/pages/SingleCountryCont/index.js
+++ b/client/src/pages/SingleCountryCont/index.js
@@ -1,36 +1,13 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import Header from '../../components/Header';
 import Footer from '../../components/Footer';
 import SingleCountryHeader from '../../components/SingleCountryHeader'
 import SingleCountry from '../../components/SingleCountry';
-import SearchCountry from '../../components/SearchCountry';
-import Dropdown from '../../components/Dropdown';
-import UserComments from '../../components/UserComments';
-import CompareCountry from '../../components/CompareCountry';
 import './SingleCountryCont.scss'
-import OpenModal from '../../components/OpenModal';
 
 
 
-
-const SingleCountryCont =
-    ({
-        countryYearIndex,
-        setCountryYearIndex,
-        currentSearchedCountry,
-        setCurrentSearchedCountry
-    }) => {
-        const [chartTypeIndex, setChartTypeIndex] = useState('Bar');
-        const [comparisonEnabled, setComparisonEnabled] = useState(false) // used for comparison toggle
-        const [comparedCountryData, setComparedCountryData] = useState([]);
-        const [comparedCountry, setComparedCountry] = useState("");
-
-        useEffect(() => {
-            if (comparisonEnabled) {
-                setChartTypeIndex('Line');
-            }
-        }, [comparisonEnabled])
-
+const SingleCountryCont = () => {
         return (
             <>
                 <Header />
@@ -104,21 +81,7 @@ const SingleCountryCont =
                         </div> */} 
                     </div>
                     <div>
-                        
-                    
-                        <SingleCountry
-                            countryYearIndex={countryYearIndex}
-                            setCountryYearIndex={setCountryYearIndex}
-                            chartTypeIndex={chartTypeIndex}
-                            currentSearchedCountry={currentSearchedCountry}
-                            setCurrentSearchedCountry={setCurrentSearchedCountry}
-                            comparisonEnabled={comparisonEnabled}
-                            setComparisonEnabled={setComparisonEnabled}
-                            comparedCountryData={comparedCountryData}
-                            setComparedCountryData={setComparedCountryData}
-                            comparedCountry={comparedCountry}
-                            setComparedCountry={setComparedCountry}
-                        />
+                        <SingleCountry />
                     </div>
                 </main>
                 <Footer />

--- a/client/src/pages/Splash/index.js
+++ b/client/src/pages/Splash/index.js
@@ -3,9 +3,8 @@ import "./Splash.scss";
 import Header from '../../components/Header';
 import Footer from '../../components/Footer';
 import SearchCountry from '../../components/SearchCountry';
-// import OpenModal from '../../components/OpenModal';
 
-const Splash = ({ countryYearIndex, setCountryYearIndex, currentSearchedCountry, setCurrentSearchedCountry }) => {
+const Splash = () => {
     return (
         <>
             <Header />
@@ -13,13 +12,7 @@ const Splash = ({ countryYearIndex, setCountryYearIndex, currentSearchedCountry,
                 <p className='tag'>Looking to relocate? Start your search here.</p>
                 <div className='splash'>
                     <div className="searchRespCenter">
-                        {/* <OpenModal /> */}
-                        <SearchCountry 
-                            countryYearIndex={countryYearIndex} 
-                            setCountryYearIndex={setCountryYearIndex}
-                            currentSearchedCountry={currentSearchedCountry}
-                            setCurrentSearchedCountry={setCurrentSearchedCountry}
-                        />
+                        <SearchCountry />
                     </div>
                 </div>
                 <p className="overview"> 
@@ -28,9 +21,8 @@ const Splash = ({ countryYearIndex, setCountryYearIndex, currentSearchedCountry,
                 </p>
             </main>
             <Footer />
-            
         </>
-    )
-}
+    );
+};
 
 export default Splash;

--- a/client/src/utils/CountryContext.js
+++ b/client/src/utils/CountryContext.js
@@ -4,27 +4,40 @@ import { getSavedCountries, saveCountries } from './localStorage';
 export const SearchContext = createContext();
 export const useSearch = () => useContext(SearchContext);
 
-export const SearchProvider= ({children})=>{
-    const [searches, setSearches] = useState(getSavedCountries());
+export const SearchProvider = ({ children })=>{
+  // const below relate to states that track the user's current searched country
+  const [countryYearIndex, setCountryYearIndex] = useState(9);
+  const [currentSearchedCountry, setCurrentSearchedCountry] = useState("");
 
-    useEffect(() => {
-      return () => saveCountries(searches);
-    });
+  // const below relate to saving search history
+  const [searches, setSearches] = useState(getSavedCountries());
 
-    const addSearch = (search)=>{
-        setSearches([search,...searches]);
-        saveCountries(searches);
-        
-    }
-    const updateSearch = (search)=>{
-      const index=searches.findIndex(val=>val.name===search.name);
-      searches[index]=search;
-      saveCountries(searches);
-    }
+  useEffect(() => {
+    return () => saveCountries(searches);
+  });
+
+  const addSearch = (search)=>{
+      setSearches([search,...searches]);
+      saveCountries(searches);   
+  }
+  const updateSearch = (search)=>{
+    const index=searches.findIndex(val=>val.name===search.name);
+    searches[index]=search;
+    saveCountries(searches);
+  }
 
   // The provider component will wrap all other components inside of it that need access to our global state
   return (
-    <SearchContext.Provider value={{ searches, addSearch,updateSearch }}>
+    <SearchContext.Provider 
+      value={{ 
+        searches, 
+        addSearch, 
+        updateSearch,
+        countryYearIndex, 
+        setCountryYearIndex, 
+        currentSearchedCountry, 
+        setCurrentSearchedCountry 
+    }}>
       {children}
     </SearchContext.Provider>
   );

--- a/client/src/utils/DrawerContext.js
+++ b/client/src/utils/DrawerContext.js
@@ -1,0 +1,34 @@
+import React, { createContext, useState, useContext, useEffect } from 'react';
+
+export const DrawerContext = createContext();
+export const useDrawer = () => useContext(DrawerContext);
+
+export const DrawerProvider = ({ children }) => {
+  const [chartTypeIndex, setChartTypeIndex] = useState('Bar');
+  const [comparisonEnabled, setComparisonEnabled] = useState(false) // used for comparison toggle
+  const [comparedCountryData, setComparedCountryData] = useState([]);
+  const [comparedCountry, setComparedCountry] = useState("");
+
+  useEffect(() => {
+    if (comparisonEnabled) {
+        setChartTypeIndex('Line');
+    };
+  }, [comparisonEnabled]);
+
+  return (
+    <DrawerContext.Provider 
+      value={{ 
+        chartTypeIndex,
+        setChartTypeIndex,
+        comparisonEnabled,
+        setComparisonEnabled,
+        comparedCountryData,
+        setComparedCountryData,
+        comparedCountry,
+        setComparedCountry
+      }}
+    >
+      {children}
+    </DrawerContext.Provider>
+  );
+};


### PR DESCRIPTION
- Leveraging useContext, createContext to mitigate use of prop drilling between components and passing props to components that don't use them but instead act as medium to pass eventually to children components that do use props
- Adding in states related to searching a country to CountryContext as well as creating a new utils DrawerContext that contains states related to drawer menu logic and compareCountry logic that is enabled via opening drawer menu. The naming of some files may be changed a bit more later to better encapsulate their contents but for now this should be fine
- Removing extra spacing and unused imports, etc. to clean up code.