### PR TITLE
refactoring modal and resizeWindow

### DIFF
--- a/client/src/components/CompareCountry/index.js
+++ b/client/src/components/CompareCountry/index.js
@@ -2,11 +2,12 @@ import React, { useState, useEffect } from 'react';
 import SwitchToggle from '../SwitchToggle';
 import { useQuery, useLazyQuery } from '@apollo/client';
 import { QUERY_COMPILATIONS, QUERY_SINGLE_COMPILATION } from '../../utils/queries';
-import { capitalizeFirstLetter } from '../../utils/helper';
+import { capitalizeFirstLetter, resizeWindow } from '../../utils/helper';
 import { useSearch } from '../../utils/CountryContext';
 import { useDrawer } from '../../utils/DrawerContext';
 import Modal from '../Modal';
 import ReactTooltip from 'react-tooltip';
+import GeoChart from '../GeoChart'
 import './CompareCountry.scss';
 
 const CompareCountry = () => {
@@ -30,11 +31,7 @@ const CompareCountry = () => {
   const countries = data?.countryCompilations || [];
 
   useEffect(() => {
-    const handleResizeWindow = () => setWidth(window.innerWidth);
-    window.addEventListener("resize", handleResizeWindow);
-    return () => {
-      window.removeEventListener("resize", handleResizeWindow);
-    };
+    resizeWindow(setWidth);
   }, []);
 
   // Remove extra }); here
@@ -72,6 +69,10 @@ const CompareCountry = () => {
       console.error(err);
     }
   };
+
+  const closeModal = () => {
+    setModalOpen(false);
+  }
 
   return (
     <>
@@ -111,10 +112,9 @@ const CompareCountry = () => {
               >{suggestions.countryname}</div>
             )}
           </div>
-          <Modal
-            isOpen={modalOpen}
-            onClose={() => setModalOpen(false)}
-          />
+          <Modal isOpen={modalOpen} onClose={closeModal}>
+            <GeoChart onClose={closeModal} />
+          </Modal>
         </>
       } 
       </>

--- a/client/src/components/Drawer/index.js
+++ b/client/src/components/Drawer/index.js
@@ -24,18 +24,9 @@ export default function Drawer() {
     } = useDrawer();
     const [drawerOpen, setDrawerOpen] = useState(false);
     const { loading, data } = useQuery(QUERY_COMPILATIONS);
-    const [width, setWidth] = useState(window.innerWidth);
     const drawerContainer = useRef();
 
     const countries = data?.countryCompilations || [];
-
-    useEffect(() => {
-        const handleResizeWindow = () => setWidth(window.innerWidth);
-        window.addEventListener("resize", handleResizeWindow);
-        return () => {
-            window.removeEventListener("resize", handleResizeWindow);
-        };
-    }, []);
 
     function handleDrawer () {
         setDrawerOpen(!drawerOpen);

--- a/client/src/components/Modal/index.js
+++ b/client/src/components/Modal/index.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef } from 'react';
 import ReactDOM from 'react-dom';
-import GeoChart from '../GeoChart';
 import './Modal.scss';
 
 const Modal = 

--- a/client/src/components/Modal/index.js
+++ b/client/src/components/Modal/index.js
@@ -37,9 +37,7 @@ const Modal =
   return ReactDOM.createPortal(    
     <div className="modal">
       <div className="modalElementsContainer" ref={modalRef}>
-        <GeoChart 
-          onClose={onClose} 
-        />
+        {children}
         <button onClick={onClose}>Close</button>
       </div>
     </div>,

--- a/client/src/components/SearchCountry/index.js
+++ b/client/src/components/SearchCountry/index.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { searchImage } from '../../utils/API';
+import { resizeWindow } from '../../utils/helper.js'
 import { useQuery, useMutation } from '@apollo/client';
 import { QUERY_COMPILATIONS } from '../../utils/queries';
 import { useSearch } from '../../utils/CountryContext';
@@ -9,6 +10,7 @@ import { useNavigate } from 'react-router-dom';
 import Modal from '../Modal';
 import { ADD_SEARCH_HISTORY } from '../../utils/mutations';
 import { QUERY_ME } from '../../utils/queries';
+import GeoChart from '../GeoChart'
 
 const SearchCountry = () => {
   const { 
@@ -30,11 +32,7 @@ const SearchCountry = () => {
   const { loading: loadingC, data: dataC } = useQuery(QUERY_ME);
 
   useEffect(() => {
-    const handleResizeWindow = () => setWidth(window.innerWidth);
-    window.addEventListener("resize", handleResizeWindow);
-    return () => {
-      window.removeEventListener("resize", handleResizeWindow);
-    };
+    resizeWindow(setWidth);
   }, []);
 
   const handleFormSubmit = async (e) => {
@@ -42,6 +40,8 @@ const SearchCountry = () => {
     if (!searchImgInput) {
       return false;
     }
+
+    
     const searchedImages = await searchImage(searchImgInput);
     
 
@@ -78,6 +78,10 @@ const SearchCountry = () => {
     setSuggestions([]);
   }
 
+  const closeModal = () => {
+    setModalOpen(false);
+  }
+
   return (
     <>
       <DrawerProvider>
@@ -103,10 +107,9 @@ const SearchCountry = () => {
               >{suggestions.countryname}</div>
           )}
         </div>
-        <Modal 
-            isOpen={modalOpen} 
-            onClose={() => setModalOpen(false)}
-        />
+        <Modal isOpen={modalOpen} onClose={closeModal}>
+          <GeoChart onClose={closeModal} />
+        </Modal>
       </DrawerProvider>
     </>
   );

--- a/client/src/utils/helper.js
+++ b/client/src/utils/helper.js
@@ -10,3 +10,11 @@ export const capitalizeFirstLetter = (str) => {
 
 };
 
+export const resizeWindow = (setWidth) => {
+    const handleResizeWindow = () => setWidth(window.innerWidth);
+    window.addEventListener("resize", handleResizeWindow);
+    return () => {
+        window.removeEventListener("resize", handleResizeWindow);
+    };
+};
+


### PR DESCRIPTION
- refactoring modal to no longer always include hardcoded GeoChart but rather any children passed, should allow Modal to be reusable for future features that might want to employ a modal
- lifting logic related to resizing window to exported function resizeWindow within utils/helper, using to replace previous implementation in CompareCountry and SearchCountry
- removing resizeWindow within Drawer as window size affects the optional 'Open Interactive Map' showing in CompareCountry and SearchCountry rather than having impact on drawer directly instead